### PR TITLE
Update downstreams

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,10 @@ test:
     - python -c 'import cclib; print(cclib.__version__)'
     - python -c 'from cclib.io import ccread; data = ccread("https://raw.githubusercontent.com/cclib/cclib-data/master/Gaussian/Gaussian16/water.log"); print(data.zpve)'
   downstreams:
+    - aiida-gaussian
+    - aqme
+    - dbstep
     - morfeus-ml
-    - quacc
     # - rmg (not on conda-forge, located at https://anaconda.org/rmg/rmg but not updated)
 
 about:


### PR DESCRIPTION
On conda-forge I found that aiida-gaussian, aqme, and dbstep all depend on cclib, while quacc has removed its dependency.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
